### PR TITLE
Update disable_reset_authorship_colours.js

### DIFF
--- a/static/js/disable_reset_authorship_colours.js
+++ b/static/js/disable_reset_authorship_colours.js
@@ -1,5 +1,13 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$; // use jQuery
 
 exports.postAceInit = function (hook_name, args, cb) {
-    $("li[data-key='clearauthorship']").hide();
+    // get clearauthorship item
+	var item = $('li[data-key="clearauthorship"]');
+	// check if the item is sorrounded by separators, then hide the previous one
+	if (item.prev('.separator').length == 1 &&
+		item.next('.separator').length == 1) {
+	  item.prev('.separator').remove();
+	}	
+	// hide the item
+	item.remove();
 }


### PR DESCRIPTION
The item is removed, in order to prevent unwanted use of developer tools to unhide the button.
It also checks if the button is sorrounded by separators (by default it should be), then remove the previous one.
