### PR TITLE
fix: add missing callback invocation in postAceInit hook

### DIFF
--- a/static/js/disable_reset_authorship_colours.js
+++ b/static/js/disable_reset_authorship_colours.js
@@ -10,4 +10,5 @@ exports.postAceInit = (hookName, args, cb) => {
   }
   // hide the item
   item.remove();
+  return cb();
 };


### PR DESCRIPTION
Found during a systematic audit of all Etherpad plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)