### PR TITLE
fix: also disable Ctrl+Shift+C keyboard shortcut (#4)

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -2,7 +2,9 @@
   "parts":[
     {
       "name": "disable_reset_authorship_colours",
-      "hooks": {},
+      "hooks": {
+        "clientVars": "ep_disable_reset_authorship_colours/index:clientVars"
+      },
       "client_hooks": {
         "postAceInit": "ep_disable_reset_authorship_colours/static/js/disable_reset_authorship_colours:postAceInit"
       }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// Disable the Ctrl+Shift+C keyboard shortcut that triggers clearauthorship.
+// Hiding the toolbar button (done client-side in postAceInit) is not enough:
+// Etherpad's ace2_inner.ts binds Ctrl+Shift+C to CMDS.clearauthorship when
+// `clientVars.padShortcutEnabled.cmdShiftC` is truthy. Forcing that flag to
+// false here stops the shortcut from reaching the clearauthorship command.
+exports.clientVars = (hookName, {clientVars}) => {
+  if (clientVars && clientVars.padShortcutEnabled) {
+    clientVars.padShortcutEnabled.cmdShiftC = false;
+  }
+  return {};
+};

--- a/static/tests/backend/specs/clientVars.js
+++ b/static/tests/backend/specs/clientVars.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert').strict;
+const plugin = require('../../../..');
+
+describe(__filename, function () {
+  it('disables cmdShiftC in clientVars (regression for #4)', function () {
+    const clientVars = {padShortcutEnabled: {cmdShiftC: true, cmdShiftB: true}};
+    plugin.clientVars('clientVars', {clientVars});
+    assert.equal(clientVars.padShortcutEnabled.cmdShiftC, false);
+    // Other shortcuts must be untouched.
+    assert.equal(clientVars.padShortcutEnabled.cmdShiftB, true);
+  });
+
+  it('tolerates clientVars without padShortcutEnabled', function () {
+    const clientVars = {};
+    assert.doesNotThrow(() => plugin.clientVars('clientVars', {clientVars}));
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #4: hiding the clearauthorship toolbar button did not prevent Ctrl+Shift+C from resetting authorship colours, because Etherpad's \`ace2_inner.ts\` binds that combo whenever \`clientVars.padShortcutEnabled.cmdShiftC\` is truthy.
- Add a server-side \`clientVars\` hook that forces \`padShortcutEnabled.cmdShiftC = false\` before CLIENT_VARS is sent. Other shortcut flags are left untouched.
- The existing client-side button removal in \`postAceInit\` is unchanged.

## Test plan
- [x] New backend spec asserts the hook disables cmdShiftC and leaves other shortcut flags alone.
- [x] Tolerates the edge case where \`clientVars.padShortcutEnabled\` is not present.