### PR TITLE
chore: declare @feature:clear-authorship disable + use disables-aware test runner

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,11 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep.json declares `disables: ["@feature:clear-authorship"]`,
+          # so the helper runs two passes — regression (everything not
+          # tagged @feature:clear-authorship must pass) + honesty (every
+          # test tagged @feature:clear-authorship must FAIL because the
+          # plugin disables the clear-authorship-colours button).
+          # See doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,4 +1,5 @@
 {
+  "disables": ["@feature:clear-authorship"],
   "parts":[
     {
       "name": "disable_reset_authorship_colours",


### PR DESCRIPTION
Last in the disable_* propagation series. Mirrors:

- [ep_disable_chat#75](https://github.com/ether/ep_disable_chat/pull/75) — merged, shipped v0.0.40
- [ep_disable_change_author_name#84](https://github.com/ether/ep_disable_change_author_name/pull/84) — in flight
- [ep_disable_error_messages#83](https://github.com/ether/ep_disable_error_messages/pull/83) — in flight

## Changes
- `ep.json` declares `"disables": ["@feature:clear-authorship"]`.
- `.github/workflows/frontend-tests.yml` swaps `pnpm run test-ui` for `../bin/run-frontend-tests-with-disables.sh -- --project=chromium`.

See [the contract proposal](https://github.com/ether/etherpad/pull/7648) and `doc/PLUGIN_FEATURE_DISABLES.md` for the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)